### PR TITLE
Fix 1.21 tags and recipes

### DIFF
--- a/src/main/resources/data/snuffles/recipe/frosty_fluff_carpet_from_frosty_fluff.json
+++ b/src/main/resources/data/snuffles/recipe/frosty_fluff_carpet_from_frosty_fluff.json
@@ -9,7 +9,7 @@
     }
   },
   "result": {
-    "item": "snuffles:frosty_fluff_carpet",
+    "id": "snuffles:frosty_fluff_carpet",
     "count": 3
   }
 }

--- a/src/main/resources/data/snuffles/recipe/frosty_fluff_carpet_from_snuffle_fluff_carpet.json
+++ b/src/main/resources/data/snuffles/recipe/frosty_fluff_carpet_from_snuffle_fluff_carpet.json
@@ -14,7 +14,7 @@
     }
   },
   "result": {
-    "item": "snuffles:frosty_fluff_carpet",
+    "id": "snuffles:frosty_fluff_carpet",
     "count": 8
   }
 }

--- a/src/main/resources/data/snuffles/recipe/frosty_fluff_from_snuffle_fluff.json
+++ b/src/main/resources/data/snuffles/recipe/frosty_fluff_from_snuffle_fluff.json
@@ -14,7 +14,7 @@
     }
   },
   "result": {
-    "item": "snuffles:frosty_fluff",
+    "id": "snuffles:frosty_fluff",
     "count": 8
   }
 }

--- a/src/main/resources/data/snuffles/recipe/snuffle_fluff_carpet_from_frosty_fluff_carpet.json
+++ b/src/main/resources/data/snuffles/recipe/snuffle_fluff_carpet_from_frosty_fluff_carpet.json
@@ -3,7 +3,9 @@
   "ingredient": {
     "item": "snuffles:frosty_fluff_carpet"
   },
-  "result": "snuffles:snuffle_fluff_carpet",
+  "result": {
+      "id": "snuffles:snuffle_fluff_carpet"
+  },
   "experience": 0.1,
   "cookingtime": 200
 }

--- a/src/main/resources/data/snuffles/recipe/snuffle_fluff_carpet_from_snuffle_fluff.json
+++ b/src/main/resources/data/snuffles/recipe/snuffle_fluff_carpet_from_snuffle_fluff.json
@@ -9,7 +9,7 @@
     }
   },
   "result": {
-    "item": "snuffles:snuffle_fluff_carpet",
+    "id": "snuffles:snuffle_fluff_carpet",
     "count": 3
   }
 }

--- a/src/main/resources/data/snuffles/recipe/snuffle_fluff_from_frosty_fluff.json
+++ b/src/main/resources/data/snuffles/recipe/snuffle_fluff_from_frosty_fluff.json
@@ -3,7 +3,9 @@
   "ingredient": {
     "item": "snuffles:frosty_fluff"
   },
-  "result": "snuffles:snuffle_fluff",
+  "result": {
+      "id": "snuffles:snuffle_fluff"
+  },
   "experience": 0.1,
   "cookingtime": 200
 }

--- a/src/main/resources/data/snuffles/tags/item/snuffle_food.json
+++ b/src/main/resources/data/snuffles/tags/item/snuffle_food.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "#forge:crops/potato",
+    "#c:crops/potato",
     "minecraft:baked_potato"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/SnappyDragon64/Snuffles/issues/16 and https://github.com/SnappyDragon64/Snuffles/issues/17.

Confirmed this fix works in my own instance with KubeJS.